### PR TITLE
added save the report to ES functionality

### DIFF
--- a/detux.cfg
+++ b/detux.cfg
@@ -7,6 +7,12 @@ vm_exec_time=30
 #Default CPU type for executing Binary
 default_cpu=x86
 
+[elastic-search]
+#Config for pushing to ES
+es_enabled=False
+es_url=http://localhost:9200/detux/
+
+
 #Config for x86 Linux VM
 [x86-1]
 #VM IP

--- a/detux.cfg.example
+++ b/detux.cfg.example
@@ -7,6 +7,12 @@ vm_exec_time=30
 #Default CPU type for executing Binary
 default_cpu=x86
 
+[elastic-search]
+#Config for pushing to ES
+es_enabled=True
+es_url=http://localhost:9200/detux/
+
+
 #Config for x86 Linux VM
 [x86-1]
 #VM IP

--- a/detux.py
+++ b/detux.py
@@ -11,6 +11,11 @@ import json
 import sys
 import os
 import argparse
+import requests
+
+
+from ConfigParser import ConfigParser
+
 
 config_file = "detux.cfg"
 
@@ -56,7 +61,19 @@ if __name__ == "__main__":
     with open(report_path, 'w') as f:
         f.write(json_report)
     
-    print "> Report written to", report_path    
+    print "> Report written to", report_path  
+
+    # Store Result in ES
+    config = ConfigParser()
+    config.read(config_path)
+    es_enabled = config.get("es", "es_enabled")
+    es_url = config.get("es", "es_server")
+    
+
+    if es_enabled == True:
+        result = requests.put( es_server + "/reports", data=json_report)
+
+  
     
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ptyprocess==0.5.1
 pycrypto==2.6.1
 python-magic==0.4.11
 wsgiref==0.1.2
+requests==2.18.4


### PR DESCRIPTION
I have added the functionality of saving the report to ElasticSearch.
There is a switch button if the user wanted to save the output of report in ES. if its enabaled in detux.cfg data will be pushed to ES.